### PR TITLE
Fix: Correct scope for shared SQL server

### DIFF
--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -9,6 +9,7 @@ env:
   AZURE_ENV_NAME: a-riff-in-react
   AZURE_LOCATION: westus
   SHARED_SQL_SERVER_NAME: sequitur-sql-server
+  SHARED_SQL_SERVER_RG: db-rg
 
 jobs:
   build-and-deploy:
@@ -51,6 +52,7 @@ jobs:
             externalClientId=${{ secrets.ENTRA_CLIENT_ID }}
             sqlAdminPassword=${{ secrets.SQL_ADMIN_PASSWORD }}
             sharedSqlServerName=${{ env.SHARED_SQL_SERVER_NAME }}
+            sharedSqlServerResourceGroupName=${{ env.SHARED_SQL_SERVER_RG }}
           deploymentName: a-riff-in-react-${{ github.run_number }}
           failOnStdErr: false
       - name: Deploy React app to Azure Web App

--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -36,6 +36,7 @@ jobs:
             b2cSigninPolicy=${{ secrets.B2C_SIGNIN_POLICY }}
             sqlAdminPassword=${{ secrets.SQL_ADMIN_PASSWORD }}
             sharedSqlServerName=sequitur-sql-server
+            sharedSqlServerResourceGroupName=db-rg
       
       - name: Azure Logout
         run: az logout

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -23,6 +23,9 @@ param keyVaultName string = 'kv-${environmentName}'
 @description('The name of the shared SQL Server to use')
 param sharedSqlServerName string = 'sequitur-sql-server'
 
+@description('The name of the resource group containing the shared SQL Server')
+param sharedSqlServerResourceGroupName string = 'db-rg'
+
 @description('The SQL Database name')
 param sqlDatabaseName string = 'riff-react-db'
 
@@ -163,6 +166,7 @@ resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2022-10
 // Reference to the existing shared SQL Server
 resource sqlServer 'Microsoft.Sql/servers@2022-05-01-preview' existing = {
   name: sharedSqlServerName
+  scope: resourceGroup(sharedSqlServerResourceGroupName)
 }
 
 // SQL Database


### PR DESCRIPTION
This PR fixes the cross-resource-group deployment failure. It adds the 'scope' property to the Bicep template when referencing the shared SQL server, ensuring the deployment looks in the correct resource group ('db-rg').